### PR TITLE
avoid extra creation of SparkSession

### DIFF
--- a/src/main/scala/com/microsoft/spark/streaming/examples/workloads/EventhubsEventCount.scala
+++ b/src/main/scala/com/microsoft/spark/streaming/examples/workloads/EventhubsEventCount.scala
@@ -29,51 +29,20 @@ object EventhubsEventCount {
 
   def createStreamingContext(inputOptions: ArgumentMap): StreamingContext = {
 
-    val eventHubsParameters = Map[String, String](
-      "eventhubs.namespace" -> inputOptions(Symbol(EventhubsArgumentKeys.EventhubsNamespace)).asInstanceOf[String],
-      "eventhubs.name" -> inputOptions(Symbol(EventhubsArgumentKeys.EventhubsName)).asInstanceOf[String],
-      "eventhubs.policyname" -> inputOptions(Symbol(EventhubsArgumentKeys.PolicyName)).asInstanceOf[String],
-      "eventhubs.policykey" -> inputOptions(Symbol(EventhubsArgumentKeys.PolicyKey)).asInstanceOf[String],
-      "eventhubs.consumergroup" -> inputOptions(Symbol(EventhubsArgumentKeys.ConsumerGroup)).asInstanceOf[String],
-      "eventhubs.partition.count" -> inputOptions(Symbol(EventhubsArgumentKeys.PartitionCount))
-      .asInstanceOf[Int].toString,
-      "eventhubs.checkpoint.interval" -> inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds))
-      .asInstanceOf[Int].toString,
-      "eventhubs.checkpoint.dir" -> inputOptions(Symbol(EventhubsArgumentKeys.CheckpointDirectory)).asInstanceOf[String]
+    // initialization
+    val eventHubsParameters = InitUtils.createEventHubParameters(inputOptions)
+    val streamingContext = InitUtils.createNewStreamingContext(inputOptions, None)
+    val eventHubsWindowedStream = InitUtils.createEventHubsWindowedStream(
+      streamingContext,
+      eventHubsParameters,
+      inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds)).asInstanceOf[Int]
     )
 
-    /**
-      * In Spark 2.0.x, SparkConf must be initialized through EventhubsUtil so that required
-      * data structures internal to Azure Eventhubs Client get registered with the Kryo Serializer.
-      */
-
-    val sparkConfiguration : SparkConf = EventHubsUtils.initializeSparkStreamingConfigurations
-
-    sparkConfiguration.setAppName(this.getClass.getSimpleName)
-    sparkConfiguration.set("spark.streaming.receiver.writeAheadLog.enable", "true")
-    sparkConfiguration.set("spark.streaming.driver.writeAheadLog.closeFileAfterWrite", "true")
-    sparkConfiguration.set("spark.streaming.receiver.writeAheadLog.closeFileAfterWrite", "true")
-    sparkConfiguration.set("spark.streaming.stopGracefullyOnShutdown", "true")
-
-    val sparkSession : SparkSession = SparkSession.builder().config(sparkConfiguration).getOrCreate()
-
-    val streamingContext = new StreamingContext(sparkSession.sparkContext,
-      Seconds(inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds)).asInstanceOf[Int]))
-    streamingContext.checkpoint(inputOptions(Symbol(EventhubsArgumentKeys.CheckpointDirectory)).asInstanceOf[String])
-
-    val eventHubsStream = EventHubsUtils.createUnionStream(streamingContext, eventHubsParameters)
-
-    val eventHubsWindowedStream = eventHubsStream
-      .window(Seconds(inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds)).asInstanceOf[Int]))
-
     // Count number of events received the past batch
-
     val batchEventCount = eventHubsWindowedStream.count()
-
     batchEventCount.print()
 
     // Count number of events received so far
-
     val totalEventCountDStream = eventHubsWindowedStream.map(m => (StreamStatistics.streamLengthKey, 1L))
     val totalEventCount = totalEventCountDStream.updateStateByKey[Long](StreamStatistics.streamLength)
 
@@ -81,7 +50,6 @@ object EventhubsEventCount {
       .asInstanceOf[Int]))
 
     if (inputOptions.contains(Symbol(EventhubsArgumentKeys.EventCountFolder))) {
-
       totalEventCount.saveAsTextFiles(inputOptions(Symbol(EventhubsArgumentKeys.EventCountFolder))
         .asInstanceOf[String])
     }
@@ -106,12 +74,9 @@ object EventhubsEventCount {
     streamingContext.start()
 
     if(inputOptions.contains(Symbol(EventhubsArgumentKeys.TimeoutInMinutes))) {
-
       streamingContext.awaitTerminationOrTimeout(inputOptions(Symbol(EventhubsArgumentKeys.TimeoutInMinutes))
         .asInstanceOf[Long] * 60 * 1000)
-    }
-    else {
-
+    } else {
       streamingContext.awaitTermination()
     }
   }

--- a/src/main/scala/com/microsoft/spark/streaming/examples/workloads/EventhubsToAzureSQLTable.scala
+++ b/src/main/scala/com/microsoft/spark/streaming/examples/workloads/EventhubsToAzureSQLTable.scala
@@ -31,19 +31,6 @@ object EventhubsToAzureSQLTable {
 
   def createStreamingContext(inputOptions: ArgumentMap): StreamingContext = {
 
-    val eventHubsParameters = Map[String, String](
-      "eventhubs.namespace" -> inputOptions(Symbol(EventhubsArgumentKeys.EventhubsNamespace)).asInstanceOf[String],
-      "eventhubs.name" -> inputOptions(Symbol(EventhubsArgumentKeys.EventhubsName)).asInstanceOf[String],
-      "eventhubs.policyname" -> inputOptions(Symbol(EventhubsArgumentKeys.PolicyName)).asInstanceOf[String],
-      "eventhubs.policykey" -> inputOptions(Symbol(EventhubsArgumentKeys.PolicyKey)).asInstanceOf[String],
-      "eventhubs.consumergroup" -> inputOptions(Symbol(EventhubsArgumentKeys.ConsumerGroup)).asInstanceOf[String],
-      "eventhubs.partition.count" -> inputOptions(Symbol(EventhubsArgumentKeys.PartitionCount))
-      .asInstanceOf[Int].toString,
-      "eventhubs.checkpoint.interval" -> inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds))
-      .asInstanceOf[Int].toString,
-      "eventhubs.checkpoint.dir" -> inputOptions(Symbol(EventhubsArgumentKeys.CheckpointDirectory)).asInstanceOf[String]
-    )
-
     val sqlDatabaseConnectionString : String = StreamUtilities.getSqlJdbcConnectionString(
       inputOptions(Symbol(EventhubsArgumentKeys.SQLServerFQDN)).asInstanceOf[String],
       inputOptions(Symbol(EventhubsArgumentKeys.SQLDatabaseName)).asInstanceOf[String],
@@ -52,29 +39,15 @@ object EventhubsToAzureSQLTable {
 
     val sqlTableName: String = inputOptions(Symbol(EventhubsArgumentKeys.EventSQLTable)).asInstanceOf[String]
 
-    /**
-      * In Spark 2.0.x, SparkConf must be initialized through EventhubsUtil so that required
-      * data structures internal to Azure Eventhubs Client get registered with the Kryo Serializer.
-      */
-
-    val sparkConfiguration : SparkConf = EventHubsUtils.initializeSparkStreamingConfigurations
-
-    sparkConfiguration.setAppName(this.getClass.getSimpleName)
-    sparkConfiguration.set("spark.streaming.receiver.writeAheadLog.enable", "true")
-    sparkConfiguration.set("spark.streaming.driver.writeAheadLog.closeFileAfterWrite", "true")
-    sparkConfiguration.set("spark.streaming.receiver.writeAheadLog.closeFileAfterWrite", "true")
-    sparkConfiguration.set("spark.streaming.stopGracefullyOnShutdown", "true")
-
-    val sparkSession : SparkSession = SparkSession.builder().config(sparkConfiguration).getOrCreate()
-
-    val streamingContext = new StreamingContext(sparkSession.sparkContext,
-      Seconds(inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds)).asInstanceOf[Int]))
-    streamingContext.checkpoint(inputOptions(Symbol(EventhubsArgumentKeys.CheckpointDirectory)).asInstanceOf[String])
-
-    val eventHubsStream = EventHubsUtils.createUnionStream(streamingContext, eventHubsParameters)
-
-    val eventHubsWindowedStream = eventHubsStream
-      .window(Seconds(inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds)).asInstanceOf[Int]))
+    val eventHubsParameters = InitUtils.createEventHubParameters(inputOptions)
+    val sparkSession = SparkSession.builder().config(InitUtils.sparkConfiguration).getOrCreate()
+    val streamingContext = InitUtils.createNewStreamingContext(inputOptions,
+      Some(sparkSession.sparkContext))
+    val eventHubsWindowedStream = InitUtils.createEventHubsWindowedStream(
+      streamingContext,
+      eventHubsParameters,
+      inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds)).asInstanceOf[Int]
+    )
 
     import com.microsoft.spark.streaming.examples.common.DataFrameExtensions._
 

--- a/src/main/scala/com/microsoft/spark/streaming/examples/workloads/EventhubsToHiveTable.scala
+++ b/src/main/scala/com/microsoft/spark/streaming/examples/workloads/EventhubsToHiveTable.scala
@@ -29,49 +29,25 @@ object EventhubsToHiveTable {
 
   def createStreamingContext(inputOptions: ArgumentMap): StreamingContext = {
 
-    val eventHubsParameters = Map[String, String](
-      "eventhubs.namespace" -> inputOptions(Symbol(EventhubsArgumentKeys.EventhubsNamespace)).asInstanceOf[String],
-      "eventhubs.name" -> inputOptions(Symbol(EventhubsArgumentKeys.EventhubsName)).asInstanceOf[String],
-      "eventhubs.policyname" -> inputOptions(Symbol(EventhubsArgumentKeys.PolicyName)).asInstanceOf[String],
-      "eventhubs.policykey" -> inputOptions(Symbol(EventhubsArgumentKeys.PolicyKey)).asInstanceOf[String],
-      "eventhubs.consumergroup" -> inputOptions(Symbol(EventhubsArgumentKeys.ConsumerGroup)).asInstanceOf[String],
-      "eventhubs.partition.count" -> inputOptions(Symbol(EventhubsArgumentKeys.PartitionCount))
-      .asInstanceOf[Int].toString,
-      "eventhubs.checkpoint.interval" -> inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds))
-      .asInstanceOf[Int].toString,
-      "eventhubs.checkpoint.dir" -> inputOptions(Symbol(EventhubsArgumentKeys.CheckpointDirectory)).asInstanceOf[String]
-    )
-
+    val eventHubsParameters = InitUtils.createEventHubParameters(inputOptions)
+    val hiveTableName: String = inputOptions(Symbol(EventhubsArgumentKeys.EventHiveTable)).
+      asInstanceOf[String]
     /**
-      * In Spark 2.0.x, SparkConf must be initialized through EventhubsUtil so that required
-      * data structures internal to Azure Eventhubs Client get registered with the Kryo Serializer.
-      */
+     * Table needs to be explicitly created to match the Parquet format in which the data is stored
+     * by default by Spark. If not explicitly created the Hive table cannot be used from Hive and
+     * can only be used from inside Spark.
+     */
+    val hiveTableDDL: String = f"CREATE TABLE IF NOT EXISTS $hiveTableName (EventContent string)" +
+      f" STORED AS PARQUET"
+    val sparkSession = SparkSession.builder.enableHiveSupport.getOrCreate
 
-    val sparkConfiguration : SparkConf = EventHubsUtils.initializeSparkStreamingConfigurations
-
-    sparkConfiguration.setAppName(this.getClass.getSimpleName)
-    sparkConfiguration.set("spark.streaming.receiver.writeAheadLog.enable", "true")
-    sparkConfiguration.set("spark.streaming.driver.writeAheadLog.closeFileAfterWrite", "true")
-    sparkConfiguration.set("spark.streaming.receiver.writeAheadLog.closeFileAfterWrite", "true")
-    sparkConfiguration.set("spark.streaming.stopGracefullyOnShutdown", "true")
-
-    val sparkSession : SparkSession = SparkSession.builder.config(sparkConfiguration).enableHiveSupport.getOrCreate
-
-    val streamingContext = new StreamingContext(sparkSession.sparkContext,
-      Seconds(inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds)).asInstanceOf[Int]))
-    streamingContext.checkpoint(inputOptions(Symbol(EventhubsArgumentKeys.CheckpointDirectory)).asInstanceOf[String])
-
-    val eventHubsStream = EventHubsUtils.createUnionStream(streamingContext, eventHubsParameters)
-
-    val eventHubsWindowedStream = eventHubsStream
-      .window(Seconds(inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds)).asInstanceOf[Int]))
-
-    val hiveTableName: String = inputOptions(Symbol(EventhubsArgumentKeys.EventHiveTable)).asInstanceOf[String]
-
-    //Table needs to be explicitly created to match the Parquet format in which the data is stored by default by
-    //Spark. If not explicitly created the Hive table cannot be used from Hive and can only be used from inside Spark.
-
-    val hiveTableDDL: String = f"CREATE TABLE IF NOT EXISTS $hiveTableName (EventContent string) STORED AS PARQUET"
+    val streamingContext = InitUtils.createNewStreamingContext(inputOptions,
+      Some(sparkSession.sparkContext))
+    val eventHubsWindowedStream = InitUtils.createEventHubsWindowedStream(
+      streamingContext,
+      eventHubsParameters,
+      inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds)).asInstanceOf[Int]
+    )
 
     sparkSession.sql(hiveTableDDL)
 

--- a/src/main/scala/com/microsoft/spark/streaming/examples/workloads/InitUtils.scala
+++ b/src/main/scala/com/microsoft/spark/streaming/examples/workloads/InitUtils.scala
@@ -1,0 +1,59 @@
+package com.microsoft.spark.streaming.examples.workloads
+
+import com.microsoft.spark.streaming.examples.arguments.EventhubsArgumentKeys
+import com.microsoft.spark.streaming.examples.arguments.EventhubsArgumentParser.ArgumentMap
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming.eventhubs.EventHubsUtils
+import org.apache.spark.streaming.{Seconds, StreamingContext}
+import org.apache.spark.{SparkConf, SparkContext}
+
+private[workloads] object InitUtils {
+
+  /**
+   * In Spark 2.0.x, SparkConf must be initialized through EventhubsUtil so that required
+   * data structures internal to Azure Eventhubs Client get registered with the Kryo Serializer.
+   */
+  val sparkConfiguration : SparkConf = EventHubsUtils.initializeSparkStreamingConfigurations
+
+  sparkConfiguration.setAppName(this.getClass.getSimpleName)
+  sparkConfiguration.set("spark.streaming.receiver.writeAheadLog.enable", "true")
+  sparkConfiguration.set("spark.streaming.driver.writeAheadLog.closeFileAfterWrite", "true")
+  sparkConfiguration.set("spark.streaming.receiver.writeAheadLog.closeFileAfterWrite", "true")
+  sparkConfiguration.set("spark.streaming.stopGracefullyOnShutdown", "true")
+
+  def createEventHubParameters(inputOptions: ArgumentMap): Map[String, String] = {
+    Map[String, String](
+      "eventhubs.namespace" -> inputOptions(Symbol(EventhubsArgumentKeys.EventhubsNamespace)).asInstanceOf[String],
+      "eventhubs.name" -> inputOptions(Symbol(EventhubsArgumentKeys.EventhubsName)).asInstanceOf[String],
+      "eventhubs.policyname" -> inputOptions(Symbol(EventhubsArgumentKeys.PolicyName)).asInstanceOf[String],
+      "eventhubs.policykey" -> inputOptions(Symbol(EventhubsArgumentKeys.PolicyKey)).asInstanceOf[String],
+      "eventhubs.consumergroup" -> inputOptions(Symbol(EventhubsArgumentKeys.ConsumerGroup)).asInstanceOf[String],
+      "eventhubs.partition.count" -> inputOptions(Symbol(EventhubsArgumentKeys.PartitionCount))
+        .asInstanceOf[Int].toString,
+      "eventhubs.checkpoint.interval" -> inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds))
+        .asInstanceOf[Int].toString,
+      "eventhubs.checkpoint.dir" -> inputOptions(Symbol(EventhubsArgumentKeys.CheckpointDirectory)).asInstanceOf[String]
+    )
+  }
+
+  def createNewStreamingContext(
+       inputOptions: ArgumentMap,
+       userProvidedSparkContext: Option[SparkContext]): StreamingContext = {
+
+    val sparkContext = userProvidedSparkContext.getOrElse(new SparkContext(sparkConfiguration))
+
+    val ssc = new StreamingContext(sparkContext,
+      Seconds(inputOptions(Symbol(EventhubsArgumentKeys.BatchIntervalInSeconds)).asInstanceOf[Int]))
+    ssc.checkpoint(inputOptions(Symbol(EventhubsArgumentKeys.CheckpointDirectory)).toString)
+    ssc
+  }
+
+  def createEventHubsWindowedStream(
+      ssc: StreamingContext,
+      eventHubsParams: Map[String, String],
+      windowSize: Int): DStream[Array[Byte]] = {
+    val eventHubsStream = EventHubsUtils.createUnionStream(ssc, eventHubsParams)
+    eventHubsStream.window(Seconds(windowSize))
+  }
+}


### PR DESCRIPTION
This PR fixes the extra creation of SparkSession instances

This PR is based on the changes of https://github.com/hdinsight/spark-streaming-data-persistence-examples/pull/1